### PR TITLE
Adding manifest option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Library for building a Run on Slack Deno project. The artifacts produced from th
 
 The top level `mod.ts` file can be run as a Deno program. It takes up to 3 command line arguments:
 
-* `--source="/path/to/project/"` Defaults to the current working directory
-* `--output="/path/to/build/artifacts/"` Optional if `--manifest` is set. Will print to stdout out if omitted
+* `--source="relative/path/to/project"` Where the builder will look for relevant files. Defaults to the current working directory
+* `--output="relative/path/to/output/"` Where ouput files will be written. Optional if `--manifest` is set. Will print to stdout out if omitted
 * `--manifest` Will only generate the manifest.json file
 
 ```
@@ -13,14 +13,11 @@ deno run -q --unstable --allow-write --allow-read ./src/mod.ts --source="samples
 ```
 
 
-The `source` path will be used for where the builder will look for relevant files. The `output` path is where ouput files will be written.
-
-
 1. Generates a `manifest.json` file in the `output` directory.
 
 2. Bundles any functions with `remote_environment=slack` w/ Deno into the `output` directory in a structure our runtime layer expects.
 
-## Manifest Generation
+## Manifest Generation Logic
 Allows for flexibility with how you define your manifest.
 
 * Looks for a `manifest.json` file. If it exists, use it.

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 Library for building a Run on Slack Deno project. The artifacts produced from this library are what can be deployed as a Run on Slack project.
 
-The top level `mod.ts` file can be run as a Deno program. It takes 2 command line arguments:
+The top level `mod.ts` file can be run as a Deno program. It takes up to 3 command line arguments:
 
-* `--source="/path/to/project/"`
-* `--output="/path/to/build/artifacts/"`
+* `--source="/path/to/project/"` Defaults to the current working directory
+* `--output="/path/to/build/artifacts/"` Optional if `--manifest` is set. Will print to stdout out if omitted
+* `--manifest` Will only generate the manifest.json file
 
 ```
-deno run --unstable --allow-write --allow-read ./src/mod.ts --source="samples/a" --output="dist/a"
+deno run -q --unstable --allow-write --allow-read ./src/mod.ts --source="samples/a" --output="dist/a"
 ```
 
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,6 +1,7 @@
 import * as path from "https://deno.land/std@0.127.0/path/mod.ts";
 import { Options } from './types.ts';
 
+// deno-lint-ignore no-explicit-any
 export const createFunctions = async (options: Options, manifest: any) => {
   // Find all the run on slack functions
 
@@ -34,17 +35,21 @@ export const createFunctions = async (options: Options, manifest: any) => {
       check: false,
     });
 
+    if (!options.outputDirectory) {
+      throw new Error('Cannot build function files if no output option is provided');
+    }
+
     // Write FN File and sourcemap file
     const fnFileRelative = path.join('functions', `${fnId}.js`);
     const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
     const fnSourcemapPath = path.join(options.outputDirectory, 'functions', `${fnId}.js.map`);
     
-    console.log(`wrote function file: ${fnFileRelative}`)
+    options.log(`wrote function file: ${fnFileRelative}`)
     try {
       await Deno.writeTextFile(fnBundledPath, result.files["deno:///bundle.js"]);
       await Deno.writeTextFile(fnSourcemapPath, result.files["deno:///bundle.js.map"]);
     }catch(e) {
-      console.log(e);
+      options.log(e);
       throw new Error(`Error writing bundled function file: ${fnDef.id}`, e)
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 
 export type Options = {
-  manifestFile?: string,
+  manifestOnly: boolean,
   workingDirectory: string,
-  outputDirectory: string,
+  outputDirectory?: string,
+  log: (...args: any) => void,
 }


### PR DESCRIPTION
## Summary

Adds a `--manifest` option which will only generate the manifest.json definition. If `source` is omitted when `--manifest` is set, it will print to stdout.

Made `source` optional and defaults to the current working directory.

Wrapped console.log so we can hide any output if we're printing the manifest to stdout.