### PR TITLE
Build all fns for now and clean manifest

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -8,9 +8,11 @@ export const createFunctions = async (options: Options, manifest: any) => {
   for (const fnId in manifest.functions) {
     const fnDef = manifest.functions[fnId];
 
-    if (fnDef.runtime_environment !== 'slack') {
-      continue;
-    }
+    // For now we'll bundle all functions until this is available on a manifest
+    // TODO: add this check back once we add it to the manifest definition
+    // if (fnDef.runtime_environment !== 'slack') {
+    //   continue;
+    // }
 
     if (!fnDef.source_file) {
       throw new Error(`Run on Slack function provided for ${fnDef.id}, but no source_file was provided.`)

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,6 +1,6 @@
 import { parse } from "https://deno.land/std@0.127.0/flags/mod.ts";
 import * as path from "https://deno.land/std@0.127.0/path/mod.ts";
-import { createManifest } from './manifest.ts';
+import { createManifest, cleanManifest } from './manifest.ts';
 import { createFunctions } from './functions.ts'
 import { Options } from './types.ts'
 
@@ -35,6 +35,17 @@ const run = async() => {
 
   if (!options.manifestOnly) {
     await createFunctions(options, generatedManifest);
+  }
+
+  const prunedManifest = cleanManifest(generatedManifest);
+
+  // If no output was provided, print to stdout
+  if (!options.outputDirectory) {
+    // We explicitly are writing this to stdout here, not using log()
+    console.log(JSON.stringify(prunedManifest, null, 2));
+  } else {
+    await Deno.writeTextFile(path.join(options.outputDirectory, 'manifest.json'), JSON.stringify(prunedManifest, null, 2));
+    options.log(`wrote manifest.json`);
   }
 
   const duration = Date.now() - start;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,5 +3,6 @@ export type Options = {
   manifestOnly: boolean,
   workingDirectory: string,
   outputDirectory?: string,
+  // deno-lint-ignore no-explicit-any
   log: (...args: any) => void,
 }


### PR DESCRIPTION
## Summary

Build all `functions` until `runtime_environment` to check against. Clean manifest before outputting.