### PR TITLE
handle absolute paths for source and output

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -3,8 +3,15 @@ import { Options } from './types.ts';
 
 // deno-lint-ignore no-explicit-any
 export const createFunctions = async (options: Options, manifest: any) => {
-  // Find all the run on slack functions
+  if (!options.outputDirectory) {
+    throw new Error('Cannot build function files if no output option is provided');
+  }
 
+  // Ensure functions directory exists
+  const functionsPath = path.join(options.outputDirectory, 'functions');
+  await Deno.mkdir(functionsPath);
+
+  // Find all the run on slack functions
   for (const fnId in manifest.functions) {
     const fnDef = manifest.functions[fnId];
 
@@ -36,10 +43,6 @@ export const createFunctions = async (options: Options, manifest: any) => {
       bundle: "module",
       check: false,
     });
-
-    if (!options.outputDirectory) {
-      throw new Error('Cannot build function files if no output option is provided');
-    }
 
     // Write FN File and sourcemap file
     const fnFileRelative = path.join('functions', `${fnId}.js`);

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,4 +1,5 @@
 import * as path from "https://deno.land/std@0.127.0/path/mod.ts";
+import { ensureDir } from "https://deno.land/std@0.128.0/fs/mod.ts"
 import { Options } from './types.ts';
 
 // deno-lint-ignore no-explicit-any
@@ -9,7 +10,7 @@ export const createFunctions = async (options: Options, manifest: any) => {
 
   // Ensure functions directory exists
   const functionsPath = path.join(options.outputDirectory, 'functions');
-  await Deno.mkdir(functionsPath);
+  await ensureDir(functionsPath);
 
   // Find all the run on slack functions
   for (const fnId in manifest.functions) {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -14,8 +14,8 @@ const run = async() => {
     throw new Error('An output option must be specified the --manifest flag is not set')
   }
 
-  const workingDirectory = path.join(Deno.cwd(), source||"");
-  const outputDirectory = output ? path.join(Deno.cwd(), output||"") : undefined;
+  const workingDirectory = path.isAbsolute(source||"") ? source : path.join(Deno.cwd(), source||"");
+  const outputDirectory = output ? (path.isAbsolute(output) ? output : path.join(Deno.cwd(), output||"")) : undefined;
 
   const options: Options = {
     manifestOnly,
@@ -24,12 +24,14 @@ const run = async() => {
     // deno-lint-ignore no-explicit-any
     log: (...args: any) => console.log(...args),
   }
-
+  
   // Disable logging to stdout if we're outputing a manifest.json file to stdout
   if(options.manifestOnly) {
     options.log = () => {}
   }
-
+  
+  options.log(options);
+  
   // Generate Manifest
   const generatedManifest = await createManifest(options);
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -31,7 +31,7 @@ const run = async() => {
   }
   
   options.log(options);
-  
+
   // Generate Manifest
   const generatedManifest = await createManifest(options);
 


### PR DESCRIPTION
## Summary

Adds some checks for absolute paths for both `source` and `output`
Creates the output `functions` directory if missing when building function files