### PR TITLE
adding default for output of dist and updating docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ Library for building a Run on Slack Deno project. The artifacts produced from th
 
 The top level `mod.ts` file can be run as a Deno program. It takes up to 3 command line arguments:
 
-* `--source="relative/path/to/project"` Where the builder will look for relevant files. Defaults to the current working directory
-* `--output="relative/path/to/output/"` Where ouput files will be written. Optional if `--manifest` is set. Will print to stdout out if omitted
-* `--manifest` Will only generate the manifest.json file
+* `--manifest` If passed, will only generate the manifest and skip building functions
+
+* `--source` Absolute or relative path to your project. Defaults to current working directory.
+
+* `--output` Where manifest and function files will be written to. Defaults to `dist`. If omitted with `--manifest` set the manifest will be printed to stdout.
 
 ```
-deno run -q --unstable --allow-write --allow-read ./src/mod.ts --source="samples/a" --output="dist/a"
+deno run --unstable --allow-write --allow-read https://deno.land/x/deno_slack_builder@0.0.5/mod.ts"
 ```
 
+1. Generates a `manifest.json` file in the `output` directory or prints to stdout.
 
-1. Generates a `manifest.json` file in the `output` directory.
-
-2. Bundles any functions with `remote_environment=slack` w/ Deno into the `output` directory in a structure our runtime layer expects.
+2. Bundles any functions w/ Deno into the `output` directory in a structure compatible with the Run on Slack runtime.
 
 ## Manifest Generation Logic
 Allows for flexibility with how you define your manifest.
@@ -25,4 +26,36 @@ Allows for flexibility with how you define your manifest.
 * If no `manifest.ts` exists, looks for a `manifest.js` file, and follows the same logic as `manifest.ts` does.
 
 ## Function Bundling
-* For each entry in the `functions` where `remote_environment=slack` it looks for a `source_file` property, which should be a relative path to the corresponding function file. This is then bundled for the Run on Slack Deno runtime.
+* For each entry in the `functions` where `remote_environment=slack` it looks for a `source_file` property, which should be a relative path to the corresponding function file. This is then bundled for the Run on Slack Deno runtime. The `reverse` function defined below indicates there should be a corresponding function file in the project located at `functions/reverse.ts`.
+
+```json
+"functions": {
+  "reverse": {
+    "title": "Reverse",
+    "description": "Takes a string and reverses it",
+    "source_file": "functions/reverse.ts",
+    "input_parameters": {
+      "required": [
+        "stringToReverse"
+      ],
+      "properties": {
+        "stringToReverse": {
+          "type": "string",
+          "description": "The string to reverse"
+        }
+      }
+    },
+    "output_parameters": {
+      "required": [
+        "reverseString"
+      ],
+      "properties": {
+        "reverseString": {
+          "type": "string",
+          "description": "The string in reverse"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -7,15 +7,15 @@ import { Options } from './types.ts'
 const run = async() => {
   const start = Date.now();
   // We could add additional arguments to indicate things like only generate the manifest, or only functions
-  const { source, output, manifest: manifestOnly = false } = parse(Deno.args);
+  let { source, output, manifest: manifestOnly = false } = parse(Deno.args);
 
-  // Not output required but only when only the manifest is being generated as it's printed to stdout
+  // If we're generating functions, default output to a relative dist folder
   if (!output && !manifestOnly) {
-    throw new Error('An output option must be specified the --manifest flag is not set')
+    output = "dist";
   }
 
-  const workingDirectory = path.isAbsolute(source||"") ? source : path.join(Deno.cwd(), source||"");
   const outputDirectory = output ? (path.isAbsolute(output) ? output : path.join(Deno.cwd(), output||"")) : undefined;
+  const workingDirectory = path.isAbsolute(source || "") ? source : path.join(Deno.cwd(), source || "");
 
   const options: Options = {
     manifestOnly,


### PR DESCRIPTION
## Summary

Adds a default of `dist` for `output` when `--manifest` is not set.

Updates docs to add more clarity around options and an example function