### PR TITLE
[HERMES-2321] Clean dist/ directory before bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,25 @@ Library for building a Run on Slack Deno project. The artifacts produced from th
 
 _**Note:** The examples below use version `0.0.5` of `deno-slack-builder`; check the [Releases](https://github.com/slackapi/deno-slack-builder/releases) page and be sure to use the latest version._
 
-In a directory that contains a valid manifest file (`manifest.json` or `manifest.ts`), run the following:
+In a directory that contains a valid manifest file (`manifest.json`, `manifest.js`, or `manifest.ts`), run the following:
 
 ```
 deno run --unstable --allow-write --allow-read "https://deno.land/x/deno_slack_builder@0.0.5/mod.ts"
 ```
 
-This will generate a valid Run On Slack project in a new folder named `dist`. 
+This will generate a valid Run On Slack project in a new folder named `dist`.
 
 ## Usage details
 
 The top level `mod.ts` file is executed as a Deno program, and takes up to three optional arguments:
 
 | Optional Argument | Description                                           |
-| ----------------- | ----------------------------------------------------- | 
-| `--manifest`      | If passed, will only generate the manifest and skip building functions. | 
+| ----------------- | ----------------------------------------------------- |
+| `--manifest`      | If passed, will only generate the manifest and skip building functions. |
 | `--source`        | Absolute or relative path to your project. Defaults to current working directory. |
 | `--output`        | Where manifest and function files will be written to. Defaults to `dist`. If omitted and `--manifest` is set, the manifest will be printed to stdout. |
 
-### Example Usage 
+### Example Usage
 
 **Only generate a valid Run On Slack manifest file:**
 ```
@@ -40,7 +40,7 @@ deno run --unstable --allow-write --allow-read "https://deno.land/x/deno_slack_b
 
 This Deno program bundles any functions with Deno into the output directory in a structure compatible with the Run on Slack runtime, and generates a Run On Slack `manifest.json` file.
 
-Both the manifest and the functions will be placed into a `dist` directory by default; use `--output` to specify a different target directory. You can also output to stdout by using `--manifest` (be sure to not use `--output` if you want to write to stdout). 
+Both the manifest and the functions will be placed into a `dist` directory by default; use `--output` to specify a different target directory. You can also output to stdout by using `--manifest` (be sure to not use `--output` if you want to write to stdout).
 
 ### Manifest Generation Logic
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -38,8 +38,8 @@ const run = async () => {
 
   // Clean output directory
   if (options.outputDirectory) {
-    const removedOutputDirectory = await removeDirectory(options.outputDirectory)
-    if (removedOutputDirectory) {
+    const removedDirectory = await removeDirectory(options.outputDirectory);
+    if (removedDirectory) {
       options.log(`remove directory: ${options.outputDirectory}`);
     }
   }
@@ -79,12 +79,12 @@ async function removeDirectory(directoryPath: string): Promise<boolean> {
   try {
     await Deno.remove(directoryPath, { recursive: true });
     return true;
-  } catch(err) {
+  } catch (err) {
     if (err instanceof Deno.errors.NotFound) {
       return false;
     }
 
-    throw err
+    throw err;
   }
 }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -38,7 +38,7 @@ const run = async () => {
 
   // Clean output directory
   if (options.outputDirectory) {
-    await Deno.remove(options.outputDirectory, { recursive: true })
+    await Deno.remove(options.outputDirectory, { recursive: true });
     options.log(`remove directory: ${options.outputDirectory}`);
   }
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -36,6 +36,12 @@ const run = async () => {
 
   options.log(options);
 
+  // Clean output directory
+  if (options.outputDirectory) {
+    await Deno.remove(options.outputDirectory, { recursive: true })
+    options.log(`remove directory: ${options.outputDirectory}`);
+  }
+
   // Generate Manifest
   const generatedManifest = await createManifest(options);
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -38,8 +38,10 @@ const run = async () => {
 
   // Clean output directory
   if (options.outputDirectory) {
-    await Deno.remove(options.outputDirectory, { recursive: true });
-    options.log(`remove directory: ${options.outputDirectory}`);
+    const removedOutputDirectory = await removeDirectory(options.outputDirectory)
+    if (removedOutputDirectory) {
+      options.log(`remove directory: ${options.outputDirectory}`);
+    }
   }
 
   // Generate Manifest
@@ -66,5 +68,24 @@ const run = async () => {
   const duration = Date.now() - start;
   options.log(`duration: ${duration}ms`);
 };
+
+/**
+ * Recursively deletes the specified directory.
+ *
+ * @param directoryPath the directory to delete
+ * @returns true when the directory is deleted or throws unexpected errors
+ */
+async function removeDirectory(directoryPath: string): Promise<boolean> {
+  try {
+    await Deno.remove(directoryPath, { recursive: true });
+    return true;
+  } catch(err) {
+    if (err instanceof Deno.errors.NotFound) {
+      return false;
+    }
+
+    throw err
+  }
+}
 
 run();


### PR DESCRIPTION
### Summary

This pull request removes the `dist/` directory before writing the manifest and functions to the filesystem. This fixes the problem where artifacts would persist between builds, such as removing or renaming a function file.

### Question

- [x] Do we always want to delete the `dist/` directory? (Answer: Yes, we can always add an option to not, later)
  - [x] Is it safe to clean/delete custom directories such as `--output my/build/`?

### Test steps

```bash
# Build a project without a dist/
$ cd my-project/
$ rm -rf dist/
$ deno run --unstable --allow-write --allow-read ../path/to/deno-slack-builder/src/mod.ts

# Build a project with a dist/
$ mkdir -p dist/
$ deno run --unstable --allow-write --allow-read ../path/to/deno-slack-builder/src/mod.ts
# Confirm output "removed directory: path/to/dist"
```