### PR TITLE
Provide link to import map when using Deno emit

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -46,6 +46,7 @@ export const createFunctions = async (options: Options, manifest: any) => {
     const result = await Deno.emit(fnFilePath, {
       bundle: "module",
       check: false,
+      importMapPath: `${options.workingDirectory}/import_map.json`,
     });
 
     // Write FN File and sourcemap file


### PR DESCRIPTION
# Summary
When we emit a function file we need to make sure to use the import map from the app.

This does have the assumption that the developers `import_map.json` will be at the project root, which we also have in the CLI.

## Details
If a developer had an import map like 
```json
{
  "imports": {
    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@0.0.1/",
    "deno-slack-api/": "https://deno.land/x/deno_slack_api@0.0.2/"
  }
}
```

and they tried to import and reference those libraries within a function file like
```ts
import { SlackAPI } from "deno-slack-api/mod.ts" 

const reverse = async ({ inputs, env, token }: any) => {
  console.log(`reversing ${inputs.stringToReverse}.`);
  console.log(`SLACK_API_URL=${env["SLACK_API_URL"]}`);

  const reverseString = inputs.stringToReverse.split("").reverse().join("");

  const _client = SlackAPI(token, { slackApiUrl: env["SLACK_API_URL"] });

  return await {
    outputs: { reverseString },
  };
};

export default reverse;

```
the builder would error out because it couldn't resolve `deno-slack-api/`.