### PR TITLE
Add messaging around source_file

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -38,6 +38,11 @@ export const createFunctions = async (options: Options, manifest: any) => {
         throw new Error(`Could not find file: ${fnFilePath}`);
       }
     } catch (e) {
+      if (e instanceof Deno.errors.NotFound) {
+        throw new Error(
+          `Could not find file: ${fnFilePath}. Make sure your function's "source_file" is relative to your project root.`,
+        );
+      }
       throw new Error(e);
     }
 


### PR DESCRIPTION
###  Summary
Catches when `Deno.stat()`can't find the function file to build and adds messaging around the `source_file` param

JIRA Ticket: https://jira.tinyspeck.com/browse/HERMES-2476
Convo: https://slack-pde.slack.com/archives/C03BS52QLPJ/p1649960695981079
Relevant runtime PR: https://github.com/slackapi/deno-slack-runtime/pull/11

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
