### PR TITLE
Move `properties` above `required`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Allows for flexibility with how you define your manifest.
           "description": "The string to reverse"
         }
       },
-      "required": ["stringToReverse"],
+      "required": ["stringToReverse"]
     },
     "output_parameters": {
       "properties": {

--- a/README.md
+++ b/README.md
@@ -60,26 +60,22 @@ Allows for flexibility with how you define your manifest.
     "description": "Takes a string and reverses it",
     "source_file": "functions/reverse.ts",
     "input_parameters": {
-      "required": [
-        "stringToReverse"
-      ],
       "properties": {
         "stringToReverse": {
           "type": "string",
           "description": "The string to reverse"
         }
-      }
+      },
+      "required": ["stringToReverse"],
     },
     "output_parameters": {
-      "required": [
-        "reverseString"
-      ],
       "properties": {
         "reverseString": {
           "type": "string",
           "description": "The string in reverse"
         }
-      }
+      },
+      "required": ["reverseString"],
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Allows for flexibility with how you define your manifest.
           "description": "The string in reverse"
         }
       },
-      "required": ["reverseString"],
+      "required": ["reverseString"]
     }
   }
 }


### PR DESCRIPTION
Keeping our code samples consistent now that we've opted to have `required` after `properties` in the input and output parameter definitions. 