### PR TITLE
Make sure builder always validates function files

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -6,6 +6,12 @@ export const validateAndCreateFunctions = async (
   // deno-lint-ignore no-explicit-any
   manifest: any,
 ) => {
+  if (options.outputDirectory) {
+    // Ensure functions directory exists
+    const functionsPath = path.join(options.outputDirectory, "functions");
+    await ensureDir(functionsPath);
+  }
+
   // Find all the run on slack functions
   for (const fnId in manifest.functions) {
     const fnDef = manifest.functions[fnId];
@@ -67,10 +73,6 @@ const createFunctionFile = async (
   fnId: string,
   fnFilePath: string,
 ) => {
-  // Ensure functions directory exists
-  const functionsPath = path.join(options.outputDirectory, "functions");
-  await ensureDir(functionsPath);
-
   // Bundle File
   let isImportMapPresent = false;
   const importMapPath = `${options.workingDirectory}/import_map.json`;

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -1,79 +1,42 @@
 import { Options } from "./types.ts";
 import { ensureDir, path } from "./deps.ts";
 
-// deno-lint-ignore no-explicit-any
-export const createFunctions = async (options: Options, manifest: any) => {
+export const validateAndCreateFunctions = async (
+  options: Options,
+  // deno-lint-ignore no-explicit-any
+  manifest: any,
+) => {
   // Find all the run on slack functions
   for (const fnId in manifest.functions) {
-    const fnFilePath = await getValidFunctionPath(options, manifest, fnId);
+    const fnDef = manifest.functions[fnId];
 
-    if (!options.outputDirectory && !options.manifestOnly) {
+    // For now we'll bundle all functions until this is available on a manifest
+    // TODO: add this check back once we add it to the manifest definition
+    // if (fnDef.runtime_environment !== 'slack') {
+    //   continue;
+    // }
+
+    // Always validate function paths
+    const fnFilePath = await getValidFunctionPath(options, fnId, fnDef);
+
+    // Create function files if there is an output directory provided
+    if (options.outputDirectory) {
+      createFunctionFile(options as Required<Options>, fnId, fnFilePath);
+    } else if (!options.outputDirectory && !options.manifestOnly) {
+      // If no output directory and not just outputting manifest, throw error
       throw new Error(
         "Cannot build function files if no output option is provided",
       );
-    } else if (options.outputDirectory) {
-      // Ensure functions directory exists
-      const functionsPath = path.join(options.outputDirectory, "functions");
-      await ensureDir(functionsPath);
-
-      // Bundle File
-      let isImportMapPresent = false;
-      const importMapPath = `${options.workingDirectory}/import_map.json`;
-
-      try {
-        const { isFile } = await Deno.stat(importMapPath);
-        isImportMapPresent = isFile;
-      } catch (_e) {
-        isImportMapPresent = false;
-      }
-
-      const result = await Deno.emit(fnFilePath, {
-        bundle: "module",
-        check: false,
-        importMapPath: isImportMapPresent ? importMapPath : undefined,
-      });
-
-      // Write FN File and sourcemap file
-      const fnFileRelative = path.join("functions", `${fnId}.js`);
-      const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
-      const fnSourcemapPath = path.join(
-        options.outputDirectory,
-        "functions",
-        `${fnId}.js.map`,
-      );
-
-      options.log(`wrote function file: ${fnFileRelative}`);
-      try {
-        await Deno.writeTextFile(
-          fnBundledPath,
-          result.files["deno:///bundle.js"],
-        );
-        await Deno.writeTextFile(
-          fnSourcemapPath,
-          result.files["deno:///bundle.js.map"],
-        );
-      } catch (e) {
-        options.log(e);
-        throw new Error(`Error writing bundled function file: ${fnId}`, e);
-      }
     }
   }
 };
 
 const getValidFunctionPath = async (
   options: Options,
-  // deno-lint-ignore no-explicit-any
-  manifest: any,
   fnId: string,
+  // deno-lint-ignore no-explicit-any
+  fnDef: any,
 ) => {
-  const fnDef = manifest.functions[fnId];
-
-  // For now we'll bundle all functions until this is available on a manifest
-  // TODO: add this check back once we add it to the manifest definition
-  // if (fnDef.runtime_environment !== 'slack') {
-  //   continue;
-  // }
-
   if (!fnDef.source_file) {
     throw new Error(
       `Run on Slack function provided for ${fnId}, but no source_file was provided.`,
@@ -97,4 +60,55 @@ const getValidFunctionPath = async (
     throw new Error(e);
   }
   return fnFilePath;
+};
+
+const createFunctionFile = async (
+  options: Required<Options>,
+  fnId: string,
+  fnFilePath: string,
+) => {
+  // Ensure functions directory exists
+  const functionsPath = path.join(options.outputDirectory, "functions");
+  await ensureDir(functionsPath);
+
+  // Bundle File
+  let isImportMapPresent = false;
+  const importMapPath = `${options.workingDirectory}/import_map.json`;
+
+  try {
+    const { isFile } = await Deno.stat(importMapPath);
+    isImportMapPresent = isFile;
+  } catch (_e) {
+    isImportMapPresent = false;
+  }
+
+  const result = await Deno.emit(fnFilePath, {
+    bundle: "module",
+    check: false,
+    importMapPath: isImportMapPresent ? importMapPath : undefined,
+  });
+
+  // Write FN File and sourcemap file
+  const fnFileRelative = path.join("functions", `${fnId}.js`);
+  const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
+  const fnSourcemapPath = path.join(
+    options.outputDirectory,
+    "functions",
+    `${fnId}.js.map`,
+  );
+
+  options.log(`wrote function file: ${fnFileRelative}`);
+  try {
+    await Deno.writeTextFile(
+      fnBundledPath,
+      result.files["deno:///bundle.js"],
+    );
+    await Deno.writeTextFile(
+      fnSourcemapPath,
+      result.files["deno:///bundle.js.map"],
+    );
+  } catch (e) {
+    options.log(e);
+    throw new Error(`Error writing bundled function file: ${fnId}`, e);
+  }
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -3,88 +3,98 @@ import { ensureDir, path } from "./deps.ts";
 
 // deno-lint-ignore no-explicit-any
 export const createFunctions = async (options: Options, manifest: any) => {
-  if (!options.outputDirectory) {
-    throw new Error(
-      "Cannot build function files if no output option is provided",
-    );
-  }
-
-  // Ensure functions directory exists
-  const functionsPath = path.join(options.outputDirectory, "functions");
-  await ensureDir(functionsPath);
-
   // Find all the run on slack functions
   for (const fnId in manifest.functions) {
-    const fnDef = manifest.functions[fnId];
+    const fnFilePath = await getValidFunctionPath(options, manifest, fnId);
 
-    // For now we'll bundle all functions until this is available on a manifest
-    // TODO: add this check back once we add it to the manifest definition
-    // if (fnDef.runtime_environment !== 'slack') {
-    //   continue;
-    // }
-
-    if (!fnDef.source_file) {
+    if (!options.outputDirectory && !options.manifestOnly) {
       throw new Error(
-        `Run on Slack function provided for ${fnId}, but no source_file was provided.`,
+        "Cannot build function files if no output option is provided",
       );
-    }
+    } else if (options.outputDirectory) {
+      // Ensure functions directory exists
+      const functionsPath = path.join(options.outputDirectory, "functions");
+      await ensureDir(functionsPath);
 
-    const fnFilePath = path.join(options.workingDirectory, fnDef.source_file);
+      // Bundle File
+      let isImportMapPresent = false;
+      const importMapPath = `${options.workingDirectory}/import_map.json`;
 
-    // Make sure it's a file
-    try {
-      const { isFile } = await Deno.stat(fnFilePath);
-      if (!isFile) {
-        throw new Error(`Could not find file: ${fnFilePath}`);
+      try {
+        const { isFile } = await Deno.stat(importMapPath);
+        isImportMapPresent = isFile;
+      } catch (_e) {
+        isImportMapPresent = false;
       }
-    } catch (e) {
-      if (e instanceof Deno.errors.NotFound) {
-        throw new Error(
-          `Could not find file: ${fnFilePath}. Make sure your function's "source_file" is relative to your project root.`,
+
+      const result = await Deno.emit(fnFilePath, {
+        bundle: "module",
+        check: false,
+        importMapPath: isImportMapPresent ? importMapPath : undefined,
+      });
+
+      // Write FN File and sourcemap file
+      const fnFileRelative = path.join("functions", `${fnId}.js`);
+      const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
+      const fnSourcemapPath = path.join(
+        options.outputDirectory,
+        "functions",
+        `${fnId}.js.map`,
+      );
+
+      options.log(`wrote function file: ${fnFileRelative}`);
+      try {
+        await Deno.writeTextFile(
+          fnBundledPath,
+          result.files["deno:///bundle.js"],
         );
+        await Deno.writeTextFile(
+          fnSourcemapPath,
+          result.files["deno:///bundle.js.map"],
+        );
+      } catch (e) {
+        options.log(e);
+        throw new Error(`Error writing bundled function file: ${fnId}`, e);
       }
-      throw new Error(e);
-    }
-
-    // Bundle File
-    let isImportMapPresent = false;
-    const importMapPath = `${options.workingDirectory}/import_map.json`;
-
-    try {
-      const { isFile } = await Deno.stat(importMapPath);
-      isImportMapPresent = isFile;
-    } catch (_e) {
-      isImportMapPresent = false;
-    }
-
-    const result = await Deno.emit(fnFilePath, {
-      bundle: "module",
-      check: false,
-      importMapPath: isImportMapPresent ? importMapPath : undefined,
-    });
-
-    // Write FN File and sourcemap file
-    const fnFileRelative = path.join("functions", `${fnId}.js`);
-    const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
-    const fnSourcemapPath = path.join(
-      options.outputDirectory,
-      "functions",
-      `${fnId}.js.map`,
-    );
-
-    options.log(`wrote function file: ${fnFileRelative}`);
-    try {
-      await Deno.writeTextFile(
-        fnBundledPath,
-        result.files["deno:///bundle.js"],
-      );
-      await Deno.writeTextFile(
-        fnSourcemapPath,
-        result.files["deno:///bundle.js.map"],
-      );
-    } catch (e) {
-      options.log(e);
-      throw new Error(`Error writing bundled function file: ${fnId}`, e);
     }
   }
+};
+
+const getValidFunctionPath = async (
+  options: Options,
+  // deno-lint-ignore no-explicit-any
+  manifest: any,
+  fnId: string,
+) => {
+  const fnDef = manifest.functions[fnId];
+
+  // For now we'll bundle all functions until this is available on a manifest
+  // TODO: add this check back once we add it to the manifest definition
+  // if (fnDef.runtime_environment !== 'slack') {
+  //   continue;
+  // }
+
+  if (!fnDef.source_file) {
+    throw new Error(
+      `Run on Slack function provided for ${fnId}, but no source_file was provided.`,
+    );
+  }
+
+  const fnFilePath = path.join(options.workingDirectory, fnDef.source_file);
+
+  // Make sure it's a file that exists
+  try {
+    const { isFile } = await Deno.stat(fnFilePath);
+    if (!isFile) {
+      throw new Error(`Could not find file: ${fnFilePath}`);
+    }
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) {
+      throw new Error(
+        `Could not find file: ${fnFilePath}. Make sure your function's "source_file" is relative to your project root.`,
+      );
+    }
+    throw new Error(e);
+  }
+  return fnFilePath;
 };

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,5 +1,5 @@
 import { cleanManifest, createManifest } from "./manifest.ts";
-import { createFunctions } from "./functions.ts";
+import { validateAndCreateFunctions } from "./functions.ts";
 import { Options } from "./types.ts";
 import { parse, path } from "./deps.ts";
 
@@ -46,7 +46,7 @@ const run = async () => {
   // Generate Manifest
   const generatedManifest = await createManifest(options);
 
-  await createFunctions(options, generatedManifest);
+  await validateAndCreateFunctions(options, generatedManifest);
 
   const prunedManifest = cleanManifest(generatedManifest);
 

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -46,9 +46,7 @@ const run = async () => {
   // Generate Manifest
   const generatedManifest = await createManifest(options);
 
-  if (!options.manifestOnly) {
-    await createFunctions(options, generatedManifest);
-  }
+  await createFunctions(options, generatedManifest);
 
   const prunedManifest = cleanManifest(generatedManifest);
 


### PR DESCRIPTION
# Summary
Make sure we are always validating function files exist at the location regardless of if they are outputting the manifest or not

## Details
When doing a local run we were not seeing an error until the function was triggered because during a local run the CLI passes the flag for `manifestOnly`.