### PR TITLE
Add error message to catch if Deno.emit isn't a valid function

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -84,11 +84,19 @@ const createFunctionFile = async (
     isImportMapPresent = false;
   }
 
-  const result = await Deno.emit(fnFilePath, {
-    bundle: "module",
-    check: false,
-    importMapPath: isImportMapPresent ? importMapPath : undefined,
-  });
+  let result;
+  try {
+    result = await Deno.emit(fnFilePath, {
+      bundle: "module",
+      check: false,
+      importMapPath: isImportMapPresent ? importMapPath : undefined,
+    });
+  } catch (e) {
+    console.log(
+      "This is likely due to the newest versions of Deno no longer supporting Deno.emit(). Please downgrade your version of Deno to 1.21.3",
+    );
+    throw new Error(e);
+  }
 
   // Write FN File and sourcemap file
   const fnFileRelative = path.join("functions", `${fnId}.js`);


### PR DESCRIPTION
# Summary
Wrap `Deno.emit()` in a try/catch so that we can let people know to not use Deno version `v1.22.0` or later

## Testing
- Install `1.21.3` using `curl -fsSL https://deno.land/install.sh | sh -s v1.21.3`
- Run the command `deno run -q --unstable --config=deno.jsonc --allow-read --allow-write --allow-net --allow-env --no-check <path-to-local-builder-repo>/src/mod.ts`

===============================================================

- Install `1.22.0` using `curl -fsSL https://deno.land/install.sh | sh -s v1.22.0`
- Run the command `deno run -q --unstable --config=deno.jsonc --allow-read --allow-write --allow-net --allow-env --no-check <path-to-local-builder-repo>/src/mod.ts`

_Note: Before installing, make sure to remove your old Deno install_