### PR TITLE
Replace Deno.emit() with a call to deno bundle via Deno.run()

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
     "deno.enable": true,
     "deno.lint": true,
     "deno.unstable": true,
-    "deno.importMap": "import_map.json",
     "deno.suggest.imports.hosts": {
       "https://deno.land": false
     },

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -76,11 +76,18 @@ const createFunctionFile = async (
   const fnFileRelative = path.join("functions", `${fnId}.js`);
   const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
 
+  let denoExecutablePath = "deno";
+  try {
+    denoExecutablePath = Deno.execPath();
+  } catch (e) {
+    console.log("Error calling Deno.execPath()", e);
+  }
+
   try {
     // call out to deno to handle bundling
     const p = Deno.run({
       cmd: [
-        "deno",
+        denoExecutablePath,
         "bundle",
         fnFilePath,
         fnBundledPath,

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -76,6 +76,9 @@ const createFunctionFile = async (
   const fnFileRelative = path.join("functions", `${fnId}.js`);
   const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
 
+  // We'll default to just using whatever Deno executable is on the path
+  // Ideally we should be able to rely on Deno.execPath() so we make sure to bundle with the same version of Deno
+  // that called this script. This is perhaps a bit overly cautious, so we can look to remove the defaulting here in the future.
   let denoExecutablePath = "deno";
   try {
     denoExecutablePath = Deno.execPath();

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -80,7 +80,7 @@ const createFunctionFile = async (
   try {
     denoExecutablePath = Deno.execPath();
   } catch (e) {
-    console.log("Error calling Deno.execPath()", e);
+    options.log("Error calling Deno.execPath()", e);
   }
 
   try {
@@ -101,7 +101,7 @@ const createFunctionFile = async (
 
     options.log(`wrote function file: ${fnFileRelative}`);
   } catch (e) {
-    console.log(`Error bundling function file: ${fnId}`);
+    options.log(`Error bundling function file: ${fnId}`);
     throw e;
   }
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -76,20 +76,25 @@ const createFunctionFile = async (
   const fnFileRelative = path.join("functions", `${fnId}.js`);
   const fnBundledPath = path.join(options.outputDirectory, fnFileRelative);
 
-  // call out to deno to handle bundling
-  const p = Deno.run({
-    cmd: [
-      "deno",
-      "bundle",
-      fnFilePath,
-      fnBundledPath,
-    ],
-  });
+  try {
+    // call out to deno to handle bundling
+    const p = Deno.run({
+      cmd: [
+        "deno",
+        "bundle",
+        fnFilePath,
+        fnBundledPath,
+      ],
+    });
 
-  const status = await p.status();
-  if (status.code !== 0 || !status.success) {
-    throw new Error(`Error writing bundled function file: ${fnId}`);
+    const status = await p.status();
+    if (status.code !== 0 || !status.success) {
+      throw new Error(`Error bundling function file: ${fnId}`);
+    }
+
+    options.log(`wrote function file: ${fnFileRelative}`);
+  } catch (e) {
+    console.log(`Error bundling function file: ${fnId}`);
+    throw e;
   }
-
-  options.log(`wrote function file: ${fnFileRelative}`);
 };


### PR DESCRIPTION
## Summary
This updates how we bundle function files. We were using the `Deno.emit()` api for this, but it was an unstable api, and was subsequently removed in Deno `v1.22.0`.  This is being moved to a user-land library, https://github.com/denoland/deno_emit. Rather than try to adopt that, we're going to call out to the `deno` binary via `Deno.run()` and let it bundle via it's `deno bundle` command. We may revisit this in the future and look to adopt the deno_emit library once it's a bit more built out, as it will probably give us more control over compilation options.

Some side-effects of these changes:
* We get auto-detection of a deno config file (deno.json/deno.jsonc) for free now, so import maps will resolve if configured automatically.
* We're no longer including a source map file for each function. We weren't taking advantage of these yet, but may have better options for producing them in the future as [deno_emit](https://github.com/denoland/deno_emit) evolves.

## Testing
You'll need to check this repo out locally, then in one of your projects, you can override the `build` hook in the `slack.json` file to use the local changes. 

You can run this hook command manually to test it by just running the `deno run ...` bit directly, and inspect the `dist` folder for your compiled function(s).

Run a `slack deploy` to verify the full pipeline works as expect as well.

```json
"build": "deno run -q --unstable --allow-read --allow-write --allow-net --allow-run /Users/<your-user>/<path-to>/deno-slack-builder/src/mod.ts"
```

(A subsequent PR will. update the deno-slack-hooks repo to call this new version of the builder)