### PR TITLE
Import from deep_merge directly instead of the mod.ts to avoid warning

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,4 +1,4 @@
-export { deepMerge } from "https://deno.land/std@0.134.0/collections/mod.ts";
+export { deepMerge } from "https://deno.land/std@0.134.0/collections/deep_merge.ts";
 export { parse } from "https://deno.land/std@0.134.0/flags/mod.ts";
 export { ensureDir } from "https://deno.land/std@0.134.0/fs/mod.ts";
 export * as path from "https://deno.land/std@0.134.0/path/mod.ts";


### PR DESCRIPTION
If you import any of the deno STD's `collections` helper utilities from the top-level `mod.ts`, [you will get a warning in your console](https://github.com/denoland/deno_std/blob/6e26b89f1b16daa1ffb70276aa4ee5971fe38105/collections/mod.ts#L11). (hat tip to Amar from the ROSI team for pointing me here). If you `slack deploy` any app, invoke it, then check its logs via `slack activity`, you will see this warning. After some investigation, this warning ends up coming in via this deno-slack-builder repo, and furthermore gets pulled in and [leveraged inside deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime/blob/main/src/deps.ts#L3) - which is how the above-linked warning makes its way into activity logs, as deno-slack-runtime is used to execute userland app code at runtime within Lambda.

This change alone helps reduce the size of the uncompressed runtime SDK Lambda layer used in Slack Cloud to execute userland app code from 2.7MB to 1.9MB.

Since we only need `deepMerge` from the collections STD lib, we can tweak this import!