### PR TITLE
Enforce Function File Contract earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _**Note:** The examples below use version `0.1.0` of `deno-slack-builder`; check
 
 In a directory that contains a valid manifest file (`manifest.json`, `manifest.js`, or `manifest.ts`), run the following:
 
-```
+```bash
 deno run --allow-write --allow-read "https://deno.land/x/deno_slack_builder@0.1.0/mod.ts"
 ```
 
@@ -31,12 +31,14 @@ The top level `mod.ts` file is executed as a Deno program, and takes up to three
 ### Example Usage
 
 **Only generate a valid Run On Slack manifest file:**
-```
+
+```bash
 deno run --allow-write --allow-read "https://deno.land/x/deno_slack_builder@0.1.0/mod.ts" --manifest
 ```
 
 **Generate a Run On Slack project from a /src directory:**
-```
+
+```bash
 deno run --allow-write --allow-read "https://deno.land/x/deno_slack_builder@0.1.0/mod.ts" --source src
 ```
 
@@ -55,6 +57,7 @@ Allows for flexibility with how you define your manifest.
 * If no `manifest.ts` exists, looks for a `manifest.js` file, and follows the same logic as `manifest.ts` does.
 
 ## Function Bundling
+
 * For each entry in the `functions` where `remote_environment=slack` it looks for a `source_file` property, which should be a relative path to the corresponding function file. This is then bundled for the Run on Slack Deno runtime. The `reverse` function defined below indicates there should be a corresponding function file in the project located at `functions/reverse.ts`.
 
 ```json
@@ -89,11 +92,15 @@ Allows for flexibility with how you define your manifest.
 
 If you make changes to this repo, or just want to make sure things are working as desired, you can run:
 
-    deno task test
+```bash
+deno task test
+```
 
 To get a full test coverage report, run:
 
-    deno task coverage
+```bash
+deno task coverage
+```
 
 ---
 

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -10,7 +10,7 @@
     }
   },
   "tasks": {
-    "test": "deno fmt --check && deno lint && deno test src",
-    "coverage": "deno test --coverage=.coverage src && deno coverage --exclude=fixtures --exclude=test .coverage"
+    "test": "deno fmt --check && deno lint && deno test src --allow-read",
+    "coverage": "deno test --coverage=.coverage --allow-read src && deno coverage --exclude=fixtures --exclude=test .coverage"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -10,7 +10,7 @@
     }
   },
   "tasks": {
-    "test": "deno fmt --check && deno lint && deno test src --allow-read",
+    "test": "deno fmt --check && deno lint && deno test --allow-read src",
     "coverage": "deno test --coverage=.coverage --allow-read src && deno coverage --exclude=fixtures --exclude=test .coverage"
   }
 }

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,4 +1,5 @@
 export {
   assertEquals,
   assertExists,
+  assertIsError,
 } from "https://deno.land/std@0.134.0/testing/asserts.ts";

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -1,5 +1,5 @@
 export {
   assertEquals,
   assertExists,
-  assertIsError,
+  assertRejects,
 } from "https://deno.land/std@0.134.0/testing/asserts.ts";

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -46,7 +46,9 @@ const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
   const functionModule = await import(`file://${functionFilePath}`);
-  return functionModule.default ? true : false;
+  return functionModule.default
+    ? typeof functionModule.default == "function"
+    : false;
 };
 
 const getValidFunctionPath = async (

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -42,12 +42,14 @@ export const validateAndCreateFunctions = async (
   }
 };
 
-const functionPathHasDefaultExport = async (
+const functionPathHasDefaultExport = (
   functionFilePath: string,
 ) => {
-  console.log(functionFilePath);
-  const functionModule = await import(functionFilePath);
-  return functionModule.default ? true : false;
+  throw new Error(
+    `File: ${functionFilePath}, containing your function does not define a default export handler.`,
+  );
+  // const functionModule = await import(functionFilePath);
+  // return functionModule.default ? true : false;
 };
 
 const getValidFunctionPath = async (

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -45,6 +45,7 @@ export const validateAndCreateFunctions = async (
 const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
+  console.log(functionFilePath);
   const functionModule = await import(functionFilePath);
   return functionModule.default ? true : false;
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -45,7 +45,7 @@ export const validateAndCreateFunctions = async (
 const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
-  const functionModule = await import(functionFilePath as string);
+  const functionModule = await import(functionFilePath);
   return functionModule.default ? true : false;
 };
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -42,6 +42,17 @@ export const validateAndCreateFunctions = async (
   }
 };
 
+const functionPathHasDefaultExport = async (
+  functionFilePath: string,
+) => {
+  const functionModule = await import(functionFilePath as string);
+
+  if (functionModule.default) {
+    return true;
+  }
+  return false;
+};
+
 const getValidFunctionPath = async (
   options: Options,
   fnId: string,
@@ -69,6 +80,12 @@ const getValidFunctionPath = async (
       );
     }
     throw new Error(e);
+  }
+
+  if (!functionPathHasDefaultExport(fnFilePath)) {
+    throw new Error(
+      `File: ${fnFilePath}, containing your function does not define a default export handler.`,
+    );
   }
   return fnFilePath;
 };

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -46,11 +46,7 @@ const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
   const functionModule = await import(functionFilePath as string);
-
-  if (functionModule.default) {
-    return true;
-  }
-  return false;
+  return functionModule.default ? true : false;
 };
 
 const getValidFunctionPath = async (

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -82,7 +82,7 @@ const getValidFunctionPath = async (
     throw new Error(e);
   }
 
-  if (!functionPathHasDefaultExport(fnFilePath)) {
+  if (!await functionPathHasDefaultExport(fnFilePath)) {
     throw new Error(
       `File: ${fnFilePath}, containing your function does not define a default export handler.`,
     );

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -45,7 +45,7 @@ export const validateAndCreateFunctions = async (
 const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
-  const functionModule = await import(`file://${functionFilePath}`);
+  const functionModule = await import(functionFilePath);
   return functionModule.default ? true : false;
 };
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -45,7 +45,7 @@ export const validateAndCreateFunctions = async (
 const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
-  const functionModule = await import(functionFilePath);
+  const functionModule = await import(`file://${functionFilePath}`);
   return functionModule.default ? true : false;
 };
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -42,14 +42,11 @@ export const validateAndCreateFunctions = async (
   }
 };
 
-const functionPathHasDefaultExport = (
+const functionPathHasDefaultExport = async (
   functionFilePath: string,
 ) => {
-  throw new Error(
-    `File: ${functionFilePath}, containing your function does not define a default export handler.`,
-  );
-  // const functionModule = await import(functionFilePath);
-  // return functionModule.default ? true : false;
+  const functionModule = await import(functionFilePath);
+  return functionModule.default ? true : false;
 };
 
 const getValidFunctionPath = async (

--- a/src/tests/functions/test_function_file.ts
+++ b/src/tests/functions/test_function_file.ts
@@ -1,0 +1,3 @@
+export default () => {
+  console.log("this is my slack function");
+};

--- a/src/tests/functions/test_function_no_export_file.ts
+++ b/src/tests/functions/test_function_no_export_file.ts
@@ -1,0 +1,3 @@
+export const func = () => {
+  console.log("this is my slack function");
+};

--- a/src/tests/functions/test_function_not_function_file.ts
+++ b/src/tests/functions/test_function_not_function_file.ts
@@ -1,0 +1,1 @@
+export default "hello";

--- a/src/tests/functions_test.ts
+++ b/src/tests/functions_test.ts
@@ -1,5 +1,5 @@
 import { validateAndCreateFunctions } from "../functions.ts";
-import { assertEquals, assertExists, assertIsError } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertRejects } from "../dev_deps.ts";
 import { Options } from "../types.ts";
 
 Deno.test("validateAndCreateFunctions", () => {
@@ -66,11 +66,9 @@ Deno.test("Function files with no default export should get an error", async () 
       },
     },
   };
-  try {
-    await validateAndCreateFunctions(options, manifest);
-  } catch (error) {
-    assertIsError(error);
-    return;
-  }
-  assertEquals(false, true);
+  await assertRejects(
+    () => validateAndCreateFunctions(options, manifest), // callback that returns a promise
+    Error, // Error Class
+    "default export handler", // substring of error message
+  );
 });

--- a/src/tests/functions_test.ts
+++ b/src/tests/functions_test.ts
@@ -1,6 +1,76 @@
 import { validateAndCreateFunctions } from "../functions.ts";
-import { assertExists } from "../dev_deps.ts";
+import { assertEquals, assertExists, assertIsError } from "../dev_deps.ts";
+import { Options } from "../types.ts";
 
 Deno.test("validateAndCreateFunctions", () => {
   assertExists(validateAndCreateFunctions);
+});
+
+Deno.test("Function files should have a default export", async () => {
+  const captured_log: string[] = [];
+  const options: Options = {
+    manifestOnly: true,
+    workingDirectory: Deno.cwd(),
+    log: (x) => {
+      captured_log.push(x);
+    },
+  };
+  const manifest = {
+    "functions": {
+      "test_function": {
+        "title": "Test function",
+        "description": "this is a test",
+        "source_file": "src/tests/functions/test_function_file.ts",
+        "input_parameters": {
+          "required": [],
+          "properties": {},
+        },
+        "output_parameters": {
+          "required": [],
+          "properties": {},
+        },
+      },
+    },
+  };
+
+  await validateAndCreateFunctions(
+    options,
+    manifest,
+  );
+  assertEquals("", captured_log.join(""));
+});
+
+Deno.test("Function files with no default export should get an error", async () => {
+  const captured_log: string[] = [];
+  const options: Options = {
+    manifestOnly: true,
+    workingDirectory: Deno.cwd(),
+    log: (x) => {
+      captured_log.push(x);
+    },
+  };
+  const manifest = {
+    "functions": {
+      "test_function": {
+        "title": "Test function",
+        "description": "this is a test",
+        "source_file": "src/tests/functions/test_function_no_export_file.ts",
+        "input_parameters": {
+          "required": [],
+          "properties": {},
+        },
+        "output_parameters": {
+          "required": [],
+          "properties": {},
+        },
+      },
+    },
+  };
+  try {
+    await validateAndCreateFunctions(options, manifest);
+  } catch (error) {
+    assertIsError(error);
+    return;
+  }
+  assertEquals(false, true);
 });

--- a/src/tests/functions_test.ts
+++ b/src/tests/functions_test.ts
@@ -6,7 +6,7 @@ Deno.test("validateAndCreateFunctions", () => {
   assertExists(validateAndCreateFunctions);
 });
 
-Deno.test("Function files should have a default export", async () => {
+Deno.test("validateAndCreateFunctions should not throw an exception when fed a function file that has a default export", async () => {
   const captured_log: string[] = [];
   const options: Options = {
     manifestOnly: true,
@@ -55,6 +55,39 @@ Deno.test("Function files with no default export should get an error", async () 
         "title": "Test function",
         "description": "this is a test",
         "source_file": "src/tests/functions/test_function_no_export_file.ts",
+        "input_parameters": {
+          "required": [],
+          "properties": {},
+        },
+        "output_parameters": {
+          "required": [],
+          "properties": {},
+        },
+      },
+    },
+  };
+  await assertRejects(
+    () => validateAndCreateFunctions(options, manifest),
+    Error,
+    "default export handler",
+  );
+});
+
+Deno.test("Function files not exporting a function should get an error", async () => {
+  const captured_log: string[] = [];
+  const options: Options = {
+    manifestOnly: true,
+    workingDirectory: Deno.cwd(),
+    log: (x) => {
+      captured_log.push(x);
+    },
+  };
+  const manifest = {
+    "functions": {
+      "test_function": {
+        "title": "Test function",
+        "description": "this is a test",
+        "source_file": "src/tests/functions/test_function_not_function_file.ts",
         "input_parameters": {
           "required": [],
           "properties": {},

--- a/src/tests/functions_test.ts
+++ b/src/tests/functions_test.ts
@@ -67,8 +67,8 @@ Deno.test("Function files with no default export should get an error", async () 
     },
   };
   await assertRejects(
-    () => validateAndCreateFunctions(options, manifest), // callback that returns a promise
-    Error, // Error Class
-    "default export handler", // substring of error message
+    () => validateAndCreateFunctions(options, manifest),
+    Error,
+    "default export handler",
   );
 });


### PR DESCRIPTION
###  Summary

The goal of this PR is to allow the deno slack builder to detect if a function file has a `default export` and notify the user is it does not.

ticket: HERMES-2867

Test:
1. Create a Deno project using the CLI or `cd` to an existing project
2. Run
    ```bash
    deno run -r --allow-read --allow-write --allow-net --allow-run --config=deno.jsonc 
    https://raw.githubusercontent.com/WilliamBergamin/deno-slack-builder/early-function-contract/src/mod.ts
    ```
    everything should pass
3. Edit a file containing a Function and remove the `export default handler`
4. Run
    ```bash
    deno run -r --allow-read --allow-write --allow-net --allow-run --config=deno.jsonc 
    https://raw.githubusercontent.com/WilliamBergamin/deno-slack-builder/early-function-contract/src/mod.ts
    ```
    This time something should fail and the output should contain this
    ```
    error: Uncaught (in promise) Error: File: {YOUR PATH TO BROKEN FILE}, containing your function does not define a default export handler.
    ```

I'm looking for feedback on additional testing, making sure this will work with the other components of the system

### Requirements

* [x] I've read and understood the [Contributing Guidelines](https://github.com/{project_slug}/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
